### PR TITLE
Update docker-compose.yml to use default n/w as om_internal_network

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -482,3 +482,9 @@ services:
 
 volumes:
   db-config:
+
+networks:
+  default:
+    name: om_internal_network
+    driver: bridge
+


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES/NO

## What kind of change does this PR introduce?

Bug fix, feature, docs update, ...

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
